### PR TITLE
G-14: Given user Ask Siri to add a grocery item, When user ask Siri, Then should add item to groceries

### DIFF
--- a/Groceries.xcodeproj/project.pbxproj
+++ b/Groceries.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A0624F32CE1AEA300B2E41F /* AddItemToGroceriesIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0624F22CE1AEA300B2E41F /* AddItemToGroceriesIntent.swift */; };
 		1A4964E12CDF1E5800D9DCD6 /* RemoveAllGroceriesIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4964E02CDF1E5800D9DCD6 /* RemoveAllGroceriesIntent.swift */; };
 		1A6E4B902C54E28A009DCB5B /* GroceriesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6E4B8F2C54E28A009DCB5B /* GroceriesApp.swift */; };
 		1A6E4B922C54E28A009DCB5B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6E4B912C54E28A009DCB5B /* ContentView.swift */; };
@@ -26,6 +27,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1A0624F22CE1AEA300B2E41F /* AddItemToGroceriesIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddItemToGroceriesIntent.swift; sourceTree = "<group>"; };
 		1A4964E02CDF1E5800D9DCD6 /* RemoveAllGroceriesIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveAllGroceriesIntent.swift; sourceTree = "<group>"; };
 		1A6E4B8C2C54E28A009DCB5B /* Groceries.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Groceries.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A6E4B8F2C54E28A009DCB5B /* GroceriesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroceriesApp.swift; sourceTree = "<group>"; };
@@ -57,6 +59,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1A0624F12CE1AE6900B2E41F /* AddItemToGroceries */ = {
+			isa = PBXGroup;
+			children = (
+				1A0624F22CE1AEA300B2E41F /* AddItemToGroceriesIntent.swift */,
+			);
+			path = AddItemToGroceries;
+			sourceTree = "<group>";
+		};
 		1A4964DF2CDF1E3000D9DCD6 /* RemoveAllGroceries */ = {
 			isa = PBXGroup;
 			children = (
@@ -107,6 +117,7 @@
 		1A9D3DE72C562ED40063F010 /* AppIntents */ = {
 			isa = PBXGroup;
 			children = (
+				1A0624F12CE1AE6900B2E41F /* AddItemToGroceries */,
 				1A4964DF2CDF1E3000D9DCD6 /* RemoveAllGroceries */,
 				1A9D3DE82C562EEF0063F010 /* ShowGroceriesIntent.swift */,
 				1AC8EC732CD6658F00ADA919 /* OpenGroceriesIntentViewModel.swift */,
@@ -223,6 +234,7 @@
 				1A6E4B922C54E28A009DCB5B /* ContentView.swift in Sources */,
 				1AC8EC6E2CD6537A00ADA919 /* LocalGroceryDeleter.swift in Sources */,
 				1AC8EC6A2CD64FCE00ADA919 /* GroceriesViewModel.swift in Sources */,
+				1A0624F32CE1AEA300B2E41F /* AddItemToGroceriesIntent.swift in Sources */,
 				1A6E4B942C54E28A009DCB5B /* GroceryItem.swift in Sources */,
 				1AC8EC672CD64F5100ADA919 /* LocalGroceryLoader.swift in Sources */,
 				1A6E4B902C54E28A009DCB5B /* GroceriesApp.swift in Sources */,

--- a/Groceries/AppIntents/AddItemToGroceries/AddItemToGroceriesIntent.swift
+++ b/Groceries/AppIntents/AddItemToGroceries/AddItemToGroceriesIntent.swift
@@ -1,0 +1,39 @@
+//
+//  AddItemToGroceriesIntent.swift
+//  Groceries
+//
+//  Created by arifin on 11/11/24.
+//
+
+import AppIntents
+
+struct AddItemToGroceriesIntent: AppIntent {
+    
+    static var title: LocalizedStringResource = LocalizedStringResource(stringLiteral: "Add item to groceries list")
+    
+    static var description: IntentDescription? = IntentDescription(stringLiteral: "Add an item to groceries list")
+    
+    static var openAppWhenRun: Bool = false
+    
+    @Parameter(title: "Item name")
+    var itemName: String?
+    
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        
+        guard let itemName else {
+            let dialog = IntentDialog("What grocery item you would like to add?")
+            throw $itemName.needsValueError(dialog)
+        }
+        
+        do {
+            let modelContext = GroceriesApp.sharedModelContainer.mainContext
+            let adder = LocalGroceryAdder(modelContext: modelContext)
+            try await adder.add(grocery: GroceryItem(name: itemName))
+            let dialog = IntentDialog("\(itemName) is added to your groceries list")
+            return .result(dialog: dialog)
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Groceries/AppIntents/GroceriesAppShortcutProvider.swift
+++ b/Groceries/AppIntents/GroceriesAppShortcutProvider.swift
@@ -73,5 +73,17 @@ struct GroceriesAppShortcutProvider: AppShortcutsProvider {
             shortTitle: LocalizedStringResource(stringLiteral: "Remove all groceries"),
             systemImageName: "cart.fill.badge.minus"
         )
+        
+        AppShortcut(
+            intent: AddItemToGroceriesIntent(),
+            phrases: [
+                "Add an item to \(.applicationName)",
+                "Add item to \(.applicationName)",
+                "Add an item to \(.applicationName)",
+                "Add item to \(.applicationName)",
+            ],
+            shortTitle: LocalizedStringResource(stringLiteral: "Add an item to groceries"),
+            systemImageName: "cart.badge.plus"
+        )
     }
 }

--- a/Groceries/AppIntents/OpenGroceriesIntentViewModel.swift
+++ b/Groceries/AppIntents/OpenGroceriesIntentViewModel.swift
@@ -22,3 +22,4 @@ struct OpenGroceriesIntentViewModel {
         return "Here is your groceries list: \n\(groceryList)"
     }
 }
+

--- a/Groceries/AppIntents/OpenGroceriesIntentViewModel.swift
+++ b/Groceries/AppIntents/OpenGroceriesIntentViewModel.swift
@@ -22,4 +22,3 @@ struct OpenGroceriesIntentViewModel {
         return "Here is your groceries list: \n\(groceryList)"
     }
 }
-

--- a/Groceries/View/ContentView.swift
+++ b/Groceries/View/ContentView.swift
@@ -23,14 +23,14 @@ struct ContentView: View {
             }
             .navigationTitle("Groceries")
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .automatic) {
                     Button(action: {
                         showAlert = true
                     }) {
                         Image(systemName: "plus")
                     }
                 }
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .automatic) {
                     Button(action: {
                         showDeleteAllAlert = true
                     }) {


### PR DESCRIPTION
# About
- Add a way for user to add a grocery item though Siri and AppShortcuts

# Video
| Before | After |
|--------|-------|
| <img src="" width="320"> | <img src="https://github.com/user-attachments/assets/fc222aeb-6910-457e-9acf-bff7f5a01a27" width="320"> |
| <img src="" width="320"> | <img src="https://github.com/user-attachments/assets/1be70373-3eda-4522-8abe-2a33fdaf0a0d" width="320"> |
| <img src="" width="320"> | <img src="https://github.com/user-attachments/assets/f765f57d-0547-4b12-b16b-063338502e1e" width="320"> |

# References
- [Getting started with app intents](https://useyourloaf.com/blog/getting-started-with-app-intents/)
- [WWDC - Design App Shortcuts](https://developer.apple.com/videos/play/wwdc2022/10169)

Closes: [G-14](https://github.com/users/arifinfrds/projects/1/views/1?pane=issue&itemId=86591563&issue=arifinfrds%7CiOS-SwiftUI-Groceries%7C14)